### PR TITLE
added check for video extension

### DIFF
--- a/SequenceParsing.cpp
+++ b/SequenceParsing.cpp
@@ -895,6 +895,52 @@ namespace SequenceParsing {
     {
         return _imp->extension;
     }
+
+    bool
+    FileNameContent::isVideo() const
+    {
+        std::string ext = _imp->extension;
+        std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+
+        if ( (ext == "3g2") ||
+            (ext == "3gp") ||
+            (ext == "avc") ||
+            (ext == "avi") ||
+            (ext == "dirac") ||
+            (ext == "dv") ||
+            (ext == "flv") ||
+            (ext == "h261") ||
+            (ext == "h263") ||
+            (ext == "h264") ||
+            (ext == "h265") ||
+            (ext == "h26l") ||
+            (ext == "hevc") ||
+            (ext == "m2ts") ||
+            (ext == "m4v") ||
+            (ext == "matroska") ||
+            (ext == "mj2") ||
+            (ext == "mjpeg") ||
+            (ext == "mjpg") ||
+            (ext == "mkv") ||
+            (ext == "mov") ||
+            (ext == "mp4") ||
+            (ext == "mpeg") ||
+            (ext == "mpg") ||
+            (ext == "mpjpeg") ||
+            (ext == "msf") ||
+            (ext == "mt2") ||
+            (ext == "mts") ||
+            (ext == "mxf") ||
+            (ext == "rawvideo") ||
+            (ext == "swf") ||
+            (ext == "vc1") ||
+            (ext == "webm") ||
+            (ext == "ts") ||
+            (ext == "ogv") ) {
+            return true;
+        }
+        return false;
+    }
     
     
     /**

--- a/SequenceParsing.h
+++ b/SequenceParsing.h
@@ -70,6 +70,8 @@ public:
     const std::string& getExtension() const;
 
 
+    bool isVideo() const;
+
     /**
          * @brief Returns the file pattern found in the filename with hash characters style for frame number (i.e: ###)
          * A few things about this pattern:


### PR DESCRIPTION
We need to check for video files a couple of places in Natron, so I though it would be best to add the function in SequenceParsing, since it's already used in the functions in Natron that needs to check for video files.

If it's not the best place feel free to close this request ;)
